### PR TITLE
Fix coveragerc option reading

### DIFF
--- a/git-coverage
+++ b/git-coverage
@@ -698,7 +698,9 @@ def read_coveragerc(coveragerc, section, key):
     config.read(coveragerc)
     if not config.has_section(section):
         return None
-    return config.get(section, key, None)
+    if not config.has_option(section, key):
+        return None
+    return config.get(section, key)
 
 def get_omit_patterns():
     omit = read_coveragerc(".coveragerc", "run", "omit")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='Git-Coverage',
-      version='1.0.1',
+      version='1.0.2',
       install_requires=['coverage'],
       scripts=['git-coverage']
       )


### PR DESCRIPTION
ConfigParser's get function is not like dict.get() which can use a parameter as
defaults.